### PR TITLE
Comparing dispatch_get_current_queue() with dispatch_get_main_queue()…

### DIFF
--- a/Code/utils/AkimboUtils.m
+++ b/Code/utils/AkimboUtils.m
@@ -13,13 +13,12 @@ void runOnMainThread(void (^block)(void))
 {
     // this check avoids possible deadlock resulting from
     // calling dispatch_sync() on the same queue as current one
-    dispatch_queue_t mainQueue = dispatch_get_main_queue();
-    if (mainQueue == dispatch_get_current_queue()) {
+    if ([NSThread isMainThread]) {
         // execute code in place
         block();
     } else {
         // dispatch doStuff() to main queue
-        dispatch_sync(mainQueue, block);
+        dispatch_sync(dispatch_get_main_queue(), block);
     }
 }
 


### PR DESCRIPTION
… is not only deprecated since iOS6, but unreliable according to queue.h

When dispatch_get_current_queue() is called on the main thread, it may or may not return the same value as dispatch_get_main_queue(). Comparing the two is not a valid way to test whether code is executing on the main thread.
